### PR TITLE
Fixed point interest

### DIFF
--- a/crates/loans/src/tests.rs
+++ b/crates/loans/src/tests.rs
@@ -1033,10 +1033,10 @@ fn reward_calculation_one_player_in_multi_markets_works() {
         // check status
         let supply_state = Loans::reward_supply_state(DOT);
         assert_eq!(supply_state.block, 10);
-        assert_eq!(Loans::reward_supplier_index(DOT, ALICE), 0);
+        assert_eq!(Loans::reward_supplier_index(DOT, ALICE).is_zero(), true);
         let borrow_state = Loans::reward_borrow_state(DOT);
         assert_eq!(borrow_state.block, 10);
-        assert_eq!(Loans::reward_borrower_index(DOT, ALICE), 0);
+        assert_eq!(Loans::reward_borrower_index(DOT, ALICE).is_zero(), true);
         // DOT supply:100   DOT supply reward: 0
         // DOT borrow:10    DOT borrow reward: 0
         // KSM supply:100   KSM supply reward: 0

--- a/crates/loans/src/tests/edge_cases.rs
+++ b/crates/loans/src/tests/edge_cases.rs
@@ -11,6 +11,9 @@ use sp_runtime::FixedPointNumber;
 #[test]
 fn exceeded_supply_cap() {
     new_test_ext().execute_with(|| {
+        // TODO: This test fails because an overflow occurs when more than ~5 million DOT are deposited.
+        // The overflow did not occur when interest rates were computed using `u128`, but occur now with the use of
+        // `FixedU128`. Double check whether this can be avoided with the FixedPoint implementation.
         Tokens::set_balance(RuntimeOrigin::root(), ALICE, Token(DOT), million_unit(1001), 0).unwrap();
         let amount = million_unit(501);
         assert_ok!(Loans::mint(RuntimeOrigin::signed(ALICE), Token(DOT), amount));

--- a/crates/loans/src/types.rs
+++ b/crates/loans/src/types.rs
@@ -4,6 +4,8 @@ use frame_support::pallet_prelude::*;
 use primitives::{CurrencyId, Liquidity, Rate, Ratio, Shortfall};
 use scale_info::TypeInfo;
 
+pub(crate) type UnsignedFixedPoint<T> = <T as currency::Config>::UnsignedFixedPoint;
+
 /// Container for account liquidity information
 #[derive(Encode, Decode, Eq, PartialEq, Clone, RuntimeDebug, TypeInfo)]
 pub struct AccountLiquidity<T: Config> {
@@ -81,8 +83,8 @@ pub struct Market<Balance> {
 }
 
 #[derive(PartialEq, Eq, Clone, Encode, Decode, RuntimeDebug, TypeInfo, Default)]
-pub struct RewardMarketState<BlockNumber, Balance> {
-    pub index: Balance,
+pub struct RewardMarketState<BlockNumber, Rate> {
+    pub index: Rate,
     /// total amount of staking asset user deposited
     pub block: BlockNumber,
 }


### PR DESCRIPTION
Attempts to replace usage of `u128` for storage and computation of interest rates with `FixedU128`. Looks like this causes overflows to occur if someone mints more than 5 million DOT. I need to further check if this can somehow be avoided.

Closes https://github.com/interlay/interbtc/issues/755